### PR TITLE
[JOSS Review] Fix typos in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.7.0
     hooks:
       - id: black-jupyter
 
@@ -44,9 +44,9 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.3.0]
+        additional_dependencies: [black==23.7.0]
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.0.246"
     hooks:
       - id: ruff
@@ -63,7 +63,7 @@ repos:
   #         - scipy
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.5
     hooks:
       - id: codespell
 

--- a/docs/flow.ipynb
+++ b/docs/flow.ipynb
@@ -337,7 +337,7 @@
    "id": "740b2a54",
    "metadata": {},
    "source": [
-    "Comparing the recovery factor for ideal versus real gases is enlightening. Because of the pressure variation of diffusivity, at real gas reservoirs assymptote more slowly than an ideal gas would."
+    "Comparing the recovery factor for ideal versus real gases is enlightening. Because of the pressure variation of diffusivity, at real gas reservoirs asymptote more slowly than an ideal gas would."
    ]
   },
   {

--- a/docs/fluids.ipynb
+++ b/docs/fluids.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "## Calculate viscosity\n",
     "\n",
-    "Viscosity and compressibility are the key pressure-varying diffusivity properties. Once again, these are availalbe via the `Fluid` class."
+    "Viscosity and compressibility are the key pressure-varying diffusivity properties. Once again, these are available via the `Fluid` class."
    ]
   },
   {


### PR DESCRIPTION
@frank1010111 This is a very tiny PR for https://github.com/openjournals/joss-reviews/issues/5255 that will fix some typos in the docs caught by `codespell` before we have you make a new release for archival purposes (hold off on that though until I request it in the review just in case anything else comes up).

* Fix typos:
   - 'assymptote' -> 'asymptote'
   - 'availalbe' -> 'available'

* Apply pre-commit hook updates that don't require code changes when applied.